### PR TITLE
Correções de erros gramaticais e de digitação em post sobre atomicos

### DIFF
--- a/content/en/understanding-atomics.md
+++ b/content/en/understanding-atomics.md
@@ -211,9 +211,15 @@ we have other methods on `AtomicBool`, such as `nand`, `or`, and `xor`.
 
 As you may suspect, `AtomicUsize` and `AtomicIsize` have their own methods with
 basic arithmetic (add and sub) and bitwise. And all of them are implementable
+<<<<<<< HEAD
+via software, but probably are implemented in such a way they are translated
+into a single native instruction. Although the API does not provide `mul` and
+`div`, it is not hard to implement them.
+=======
 via software, but probably are translated into a single native instruction.
 Although the API does not provide `mul` and `div`, it is not hard to implement
 them.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 ## A note on `AtomicPtr<T>`
 

--- a/content/entendendo-atomicos.md
+++ b/content/entendendo-atomicos.md
@@ -15,9 +15,15 @@ Neste post, explicarei o que são atômicos e como usá-los em Rust.
 
 # "De qualquer forma, o que seria um 'atômico'?"
 
+<<<<<<< HEAD
+Atômicos são tipos de dados com operações indivisíveis ou as próprias
+operações indivisíveis. Aqui, indivisível significa que os efeitos dessas
+operações só são observáveis quando a operação já acabou. Normalmente, as
+=======
 Atômicos são tipos de dados com operações indivisíveis, ou as próprias
 operações indivisíveis. Aqui indivisível significa que os efeitos dessas
 operações só são observáveis quando a operação já acabou. Normalmente as
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 máquinas fornecem leitura e escrita tanto divisíveis quanto indivisíveis
 sobre os inteiros nativos.
 
@@ -27,20 +33,35 @@ máquina com palavra de 64 bits. Suponha _threads_ `A`, `B` e `C`, todas com
 acesso ao endereço `p`. Se `A` faz uma escrita "divisível" de `x` em `p` ao
 mesmo tempo em que `C` faz uma leitura "divisível", `C` pode ficar com metade
 dos bits anteriores de `p` e metade dos bits de `x`. Ou um quarto desses bits.
+<<<<<<< HEAD
+Ou o estado anterior. Ou o novo estado. Na verdade, é difícil prever. Se
+a thread `A` escreve "divisivelmente" `y`, de novo em `p`, ao mesmo tempo em
+que a thread `B` escreve "divisivelmente" `z`, o resultado de `p` pode ser uma
+=======
 Ou o estado anterior. Ou o novo estado. Na verdade, é difícil de prever. Se
 a thread `A` escreve "divisivelmente" `y` de novo em `p` ao mesmo tempo em que
 a thread `B` escreve "divisivelmente" `z`, o resultado de `p` pode ser uma
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 mistura de `y` e `z` ou algo similar.
 
 Pelo fato do comportamento variar em diferentes máquinas, as linguagens de
 programação como Rust e C++ definem _data races_ como comportamento indefinido
 (_undefined behavior_). O comportamento real pode não ser "deixar um estado
+<<<<<<< HEAD
+intermediário", mas qualquer coisa, de "lançar uma exceção" até "incendiar o
+processador". Você provavelmente deve ter notado que o problema aqui são as
+operações "divisíveis". Se `A` tivesse escrito `x` em `p` atomicamente, e `C`
+tivesse lido de `p` também atomicamente, `C` veria os bits de `p` ou antes
+ou depois da escrita de `A`, mas nunca no meio. O mesmo se aplica à `A` e `B`
+escreverem atomicamente; o estado final seria ou `y` ou `z`, mas nada além disso.
+=======
 intermediário", mas qualquer coisa, desde lançar uma exceção a botar fogo
 no processador. Você provavelmente deve ter notado que o problema aqui são
 as operações "divisíveis". Se `A` tivesse escrito `x` em `p` atomicamente e
 `C` tivesse lido de `p` também atomicamente, `C` veria os bits de `p` ou antes
 ou depois da escirta de `A`, mas nunca no meio. O mesmo se aplica a `A` e `B`
 escrever atomicamente; o estado final seria ou `y` ou `z`, mas nada além disso.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 Há ainda a chamada "_race condition_" (condição de corrida). Condição de
 corrida é similar a _data race_, mas pode ocorrer até mesmo com atômicos.
@@ -54,11 +75,19 @@ deve pensar com cuidado ao escrever código atômico.
 Atualmente (rust nightly 1.28 e stable 1.26) estes tipos de dados atômics
 foram estabilizados: `AtomicPtr<T>`, `AtomicUsize`, `AtomicIsize` and
 `AtomicBool`. Eles se localizam em `core::sync::atomic` (ou
+<<<<<<< HEAD
+`std::sync::atomic`). Para explicar, escolhi o mais simples: `AtomicBool`.
+
+## `AtomicBool`
+
+É bastante simples criar um `AtomicBool`:
+=======
 `std::sync::atomic`). Pra explicar, escolhi o mais simples: `AtomicBool`.
 
 ## `AtomicBool`
 
 É bastante simples de criar um `AtomicBool`:
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 ```rust
 let atomic_bool = AtomicBool::new(true);
@@ -66,8 +95,13 @@ let atomic_bool = AtomicBool::new(true);
 
 Agora, vamos fazer leitura atômica! Mas espere... opa... `AtomicBool::load`
 (carregar) aceita dois argumentos: uma referência imutável para `self` e um
+<<<<<<< HEAD
+argumento do tipo `Ordering`. A referência para `self` acredito ser fácil de
+entender, mas e o `Ordering`? `Ordering` é um tipo que determina a... a...
+=======
 argumento do tipo `Ordering`. A referência para `self` acredito de ser fácil de
 se entender, mas e o `Ordering`? `Ordering` é um tipo que determina a... a...
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 ordem? Sim, a ordem relacionada às outras operações e às outras _threads_.
 Veja abaixo a definição de `Ordering`:
 
@@ -82,6 +116,17 @@ pub enum Ordering {
 }
 ```
 
+<<<<<<< HEAD
+Há, de modo ríspido, dois tipos de CPUs relacionados às ordens: os "fracos"
+e os "fortes". Os processadores "fracos" tem garantias naturalmente fracas a
+respeito das ordens, enquanto os processadores "fortes" tem garantias
+naturalmente fortes. Geralmente é de baixo custo para processadores "fortes"
+executarem `Acquire`, `Release` e `AcqRel`. Enquanto isso, é de alto custo para
+processadores "fracos" executarem estas ordens. Para todos eles, `Relaxed` é de
+baixo custo, e `SeqCst` é de alto custo. Exemplos de processadores "fracos" são
+os das arquiteturas ARM em geral e exemplos de "fortes" são os de arquiteturas
+x86/x86-64.
+=======
 Há, de modo ríspido, dois tipos de CPUs relacionados às orderns: os "fracos"
 e os "fortes". Os processadores "fracos" tem garantias naturalmente fracas a
 respeito das ordens, enquanto os processadores "fortes" tem garantias
@@ -90,11 +135,22 @@ executarem `Acquire`, `Release` e `AcqRel`, enquanto isso é de alto custo para
 processadores "fracos". Para todos eles `Relaxed` é de baixo custo e `SeqCst`
 é de alto custo. Exemplos de "fracos" são os das arquiteturas ARM em geral e
 exemplos de fortes são os de arquiteturas x86/x86-64.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 As únicas variantes válidas para se passar a `load` são: `Relaxed`. `Acquire` e
 `SeqCst`. Não se preocupe, as outras variantes serão explicadas já já. `Relaxed`
 é algo como "a ordem não importa mesmo". Isso permite tanto o CPU quanto o
 compilador reordenarem a operação. `SeqCst` significa "sequencialmente
+<<<<<<< HEAD
+consistente"; e não será reordenada de jeito nenhum: tudo antes da operação
+acontence antes, e tudo depois da operação acontece depois.
+
+`Acquire` é um pouco mais complexo. É o complementar de `Release`. Tudo
+(geralmente operações no estilo `store`) que acontecem depois de
+`Acquire` ficam depois de `Acquire`. Mas o compilador e o CPU são livres para
+reordenar tudo que ocorre antes de `Acquire`. Ele foi projetado para ser usado
+em operações do estilo `load` (carregar) ao adquir travas.
+=======
 consistente"; e não será reordenada de jeito nenhum. Tudo antes da operação
 acontence antes, e tudo depois da operação acontece depois.
 
@@ -103,6 +159,7 @@ acontence antes, e tudo depois da operação acontece depois.
 `Acquire` ficam depois do `Acquire`. Mas o compilador e o CPU são livres para
 reordenar tudo que ocorre antes do `Acquire`. Ele foi projetado para ser usado
 em operações do estilo `load` (carregar) enquanto adquirindo travas.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 Vejamos um exemplo com `AtomicBool::load`:
 
@@ -122,9 +179,15 @@ fn print_if_it_is(atomic: &AtomicBool) {
 Agora vamos para a próxima operação: `store` (armazenar). `store` aceita uma
 referência para `self`, o novo valor (do tipo `bool`) e um `Ordering`. Os
 `Orderings`s válidos são `Relaxed`, `Release` e `SeqCst`. `Release`, como já
+<<<<<<< HEAD
+mencionado, é usado junto a `Acquire` como um par. Tudo antes de um `Release`
+acontece antes dele, mas o CPU e o compilador são livres para reordenar tudo
+que há depois. A intenção é usá-lo ao soltar uma trava.
+=======
 mencionado, é usado junto com `Acquire` como um par. Tudo antes de um `Release`
 acontece antes dele, mas o CPU e o compilador são livres para reordenar tudo
 que acontece depois. A intenção é usá-lo ao soltar uma trava.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 Vejamos um exemplo:
 
@@ -140,7 +203,11 @@ fn store_something(atomic: &AtomicBool) {
 ```
 
 Você pode ter percebido duas coisas. Se não as percebeu, perceba agora.
+<<<<<<< HEAD
+Primeiro: `store` precisa de uma referencia apenas imutável. Isso significa que
+=======
 Primeiro: `store` precisa de uma referencia apenas imutável. Isto significa que
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 ele não precisa de uma mutabilidade "externa", mas o atômico tem mutabilidade
 interna. Segundo: atômicos só são úteis em referências compartilhadas. Eles não
 tem nada como `clone`; para clonar você pode fazer algo como
@@ -148,6 +215,21 @@ tem nada como `clone`; para clonar você pode fazer algo como
 atômico. Desse modo, é comum encapsular o atômico (ou a estrutura que mantém
 um) em um `Arc`.
 
+<<<<<<< HEAD
+Há, pelo menos, outras três operações importantes: `swap`, `compare_and_swap`,
+`compare_exchange_*`. `swap` (troca) é bastante simples: troca o argumento
+(do tipo `bool`) com o valor armazenado, e retorna o valor armazenado. `swap`
+aceita qualquer `Ordering`. `compare_and_swap` aceita um `bool`, dito "atual",
+outro `bool`, dito "novo", e o `Ordering` (qualquer um é válido).
+`compare_and_swap` é uma operação atômica bastante importante. Ela compara o
+argumento "atual" com o valor armazenado. Caso eles sejam iguais, a operação
+troca o valor armazenado com o argumento "novo". De qualquer forma, o valor
+armazenado é retornado. A operação obteve sucesso se o valor retornado é
+igual ao argumento "atual".
+
+Há ainda `compare_exchange_strong` (apenas `compare_exchange` em Rust) e
+`compare_exchange_weak` (que pode falhar espontaneamente). Estas são similares
+=======
 Há pelo menos outras três operações importantes: `swap`, `compare_and_swap`,
 `compare_exchange_*`. `swap` é bem simples: faz uma troca o argumento
 (do tipo `bool`) com o valor armazenado, e retorna o valor armazenado. `swap`
@@ -161,6 +243,7 @@ igual ao argumento "atual".
 
 Há ainda `compare_exchange_strong` (apenas `compare_exchange` em Rust). e
 `compare_exchange_weak` (que pode falhar espontaneamente). Estes são similares
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 a `compare_and_swap`, exceto pelo fato de que aceitam duas ordens: uma para
 o caso de sucesso e uma para o caso de falha. Além disso, em Rust elas retornam
 um `Result`. O fato delas retornarem um `Result` possibilita
@@ -170,17 +253,31 @@ falha tem de ser igual ou mais fraca do que a de sucesso, além de ser válida
 para um `load`.
 
 Calma aí! Eu não expliquei ainda `Ordering::AcqRel`. Ele é o que parece:
+<<<<<<< HEAD
+combina `Acquire` ao carregar e `Release` ao armazenar, para operações que
+carregam e armazenam atomicamente. Apesar de eu ter explicado tudo isso
+usando `AtomicBool`, essas operações são bastante comuns entre tipos de
+dados atômicos primitivos. Todos os tipos de dados atômicos do Rust têm
+pelo menos estas operações: `load`, `store`, `swap`, `compare_and_swap`,
+`compare_exchange` e `compare_exchange_weak`. Enfim, chega de conversa.
+Vamos agir.
+=======
 combina `Acquire` ao carregar e `Release` ao armazenar para operações que
 carregam e armazenam atomicamente. Apesar de eu ter explicado tudo isso
 usando `AtomicBool`, estas operações são bastante comuns entre tipos de
 dados atômicos primitivos. Todos os tipos de dados atômicos do Rust têm
 pelo menos estas operações: `load`, `store`, `swap`, `compare_and_swap`,
 `compare_exchange` e `compare_exchange_weak`. Chega de conversa, vamos agir.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 ## "E" lógico livre de travas (lock-free)
 
 A função abaixo recebe um booleano atômico, um booleano normal, armazena
+<<<<<<< HEAD
+o resultado de um "E" lógico entre eles, e retorna o valor anterior.
+=======
 o resultado de um "E" lógico entre eles e retorna o valor anterior.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 ```rust
 use std::sync::atomic::{AtomicBool, Ordering::{*, self}};
@@ -192,7 +289,11 @@ fn lockfree_and(x: &AtomicBool, y: bool, ord: Ordering) -> bool {
         o => o,
     });
     loop {
+<<<<<<< HEAD
+        let inner = x.compare_and_swap(stored, stored && y, ord);
+=======
         let inner = x.compare_and_swap(stored, stored & y, ord);
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
         if inner == stored {
             break inner;
         }
@@ -201,6 +302,20 @@ fn lockfree_and(x: &AtomicBool, y: bool, ord: Ordering) -> bool {
 }
 ```
 
+<<<<<<< HEAD
+Note que os efeitos da operação só são visíveis após acabarmos. Ela é, de
+algum modo, "atômica". Geralmente, esse tipo de operação é chamada "lock-free"
+(livre de travas) porque ela não usa nenhuma forma de trava. Por mais que
+tenhamos um loop de tentativas, nós não dependemos de nenhuma _thread_
+liberando o recurso. Não é uma trava!
+
+E, bem... é... Rust já fornece um método `AtomicBool::fetch_and`
+("buscar 'e'"), que provavelmente é compilado para uma única instrução nativa.
+Eu quis apenas mostrar que você pode implementá-lo com os primitivos `load` e
+`compare_and_swap` via _software_.
+[Dê uma olhada aqui](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html#method.fetch_and),
+temos outras operações em `AtomicBool`, tais como `nand` ("não 'e'"), `or`
+=======
 Note que os efeitos da operação só são visíveis após acabarmos. Isto é, de
 algum modo, "atômico". Geralmente, este tipo de operação é chamada "lock-free"
 (livre de travas) porque ela não usa nenhuma forma de trava. Por mais que
@@ -213,13 +328,20 @@ Eu quis apenas mostrar que você pode implementá-la com os primitivos `load` e
 `compare_and_swap` via _software_.
 [Dê uma olhada aqui](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html#method.fetch_and),
 Temos outras operações em `AtomicBool`, tais como `nand` ("não 'e'"), `or`
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 ("ou") e `xor` ("ou exclusivo").
 
 Como você deve suspeitar, `AtomicUsize` e `AtomicIsize` tem seus próprios
 métodos com aritmética básica (adição e subtração) e bits. Todos eles são
+<<<<<<< HEAD
+implementáveis via software, mas provavelmente são implementados para compilar
+para uma única instrução nativa. Apesar de a API não fornecer multiplicação e
+divisão, não é difícil de implementá-las.
+=======
 implementáveis via software, mas provavelmente são traduzidos em uma única
 instrução nativa. Apesar de a API não fornecer multiplicação e divisão,
 não é difícil de implementá-las.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 ## Nota sobre `AtomicPtr<T>`
 
@@ -235,7 +357,11 @@ bastante importantes em ambientes concorrentes. `T: Send` significa que `T` é
 seguro de ser mandado para outra _thread_. `T: Sync` significa que `&T` é
 seguro de ser compartilhado entre _threads_. Tipos de dados atômicos
 implementam tanto `Send` quanto `Sync`, então é seguro mandar e compartilhar
+<<<<<<< HEAD
+esses tipos com _threads_.
+=======
 estes tipos através de _threads_.
+>>>>>>> d7a50184f8966761f5f79bf057076a388c687dbc
 
 ## Bônus: implementação de spinlock
 


### PR DESCRIPTION
Correções para facilitar o entendimento do post sobre atômicos. Corrigidos: typos, erros gramaticais e frases mais confusas.